### PR TITLE
fix: merge user parameter overrides into Tooling/DataLake env configs (#40)

### DIFF
--- a/packages/constructs/L3/governance/sagemaker-project-l3-construct/lib/sagemaker-project-l3-construct.ts
+++ b/packages/constructs/L3/governance/sagemaker-project-l3-construct/lib/sagemaker-project-l3-construct.ts
@@ -546,6 +546,19 @@ export class SagemakerProjectL3Construct extends MdaaL3Construct {
       return envConfig;
     });
 
+    // Extract user overrides for Tooling/DataLake (if any) to prevent duplicates
+    const userToolingConfig = envConfigs.find(e => e.name === 'Tooling');
+    const userDataLakeConfig = envConfigs.find(e => e.name === 'DataLake');
+    const otherEnvConfigs = envConfigs.filter(e => e.name !== 'Tooling' && e.name !== 'DataLake');
+
+    // Merge user parameter overrides into Tooling compliance config;
+    // compliance overrides always win on name collision (isEditable=false)
+    const toolingUserOverrides: any[] =
+      (userToolingConfig?.configurationParameters as any)?.parameterOverrides || [];
+    const toolingOverrideMap = new Map<string, any>();
+    for (const o of toolingUserOverrides) toolingOverrideMap.set(o.name, o);
+    for (const o of getParamComplianceOverrides('Tooling')) toolingOverrideMap.set(o.name, o);
+
     // Create required Tooling environment configuration
     const toolingEnvConfig: CfnProjectProfile.EnvironmentConfigurationProperty = {
       awsRegion: { regionName: profileProps.region ?? this.region },
@@ -557,9 +570,16 @@ export class SagemakerProjectL3Construct extends MdaaL3Construct {
       deploymentMode: 'ON_CREATE',
       deploymentOrder: 1,
       configurationParameters: {
-        parameterOverrides: getParamComplianceOverrides('Tooling'),
+        parameterOverrides: Array.from(toolingOverrideMap.values()),
       },
     };
+
+    // Merge user parameter overrides into DataLake compliance config
+    const datalakeUserOverrides: any[] =
+      (userDataLakeConfig?.configurationParameters as any)?.parameterOverrides || [];
+    const datalakeOverrideMap = new Map<string, any>();
+    for (const o of datalakeUserOverrides) datalakeOverrideMap.set(o.name, o);
+    for (const o of getParamComplianceOverrides('DataLake')) datalakeOverrideMap.set(o.name, o);
 
     // Create required DataLake environment configuration
     const datalakeEnvConfig: CfnProjectProfile.EnvironmentConfigurationProperty = {
@@ -572,7 +592,7 @@ export class SagemakerProjectL3Construct extends MdaaL3Construct {
       deploymentMode: 'ON_CREATE',
       deploymentOrder: 2,
       configurationParameters: {
-        parameterOverrides: getParamComplianceOverrides('DataLake'),
+        parameterOverrides: Array.from(datalakeOverrideMap.values()),
       },
     };
 
@@ -587,7 +607,7 @@ export class SagemakerProjectL3Construct extends MdaaL3Construct {
       domainIdentifier: domainConfig.domainId,
       domainUnitIdentifier: domainUnitId,
       name: profileName,
-      environmentConfigurations: [toolingEnvConfig, datalakeEnvConfig, ...envConfigs],
+      environmentConfigurations: [toolingEnvConfig, datalakeEnvConfig, ...otherEnvConfigs],
       status: 'ENABLED',
     });
   }

--- a/packages/constructs/L3/governance/sagemaker-project-l3-construct/test/sagemaker-project.test.ts
+++ b/packages/constructs/L3/governance/sagemaker-project-l3-construct/test/sagemaker-project.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { MdaaTestApp } from '@aws-mdaa/testing';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DomainConfig } from '@aws-mdaa/datazone-constructs';
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';
 import { SagemakerProjectL3Construct } from '../lib';
@@ -165,19 +165,18 @@ describe('SagemakerProjectL3Construct', () => {
     template.resourceCountIs('AWS::DataZone::Project', 1);
   });
 
-  it('should merge user Tooling/DataLake param overrides without duplicates', () => {
-    new SagemakerProjectL3Construct(testApp.testStack, 'test-sm-construct-dup', {
+  it('should merge user ParameterOverrides into Tooling environment config', () => {
+    new SagemakerProjectL3Construct(testApp.testStack, 'test-sm-merge-1', {
       naming: testApp.naming,
       roleHelper,
       domainConfig,
       projectProfiles: {
-        'test-profile-merge': {
+        'test-profile-merge-1': {
           environments: {
-            DefaultDataLake: {},
             Tooling: {
               parameters: {
                 overrides: {
-                  CustomParam: { value: 'user-value' },
+                  CustomParam: { value: 'tooling-user-value' },
                 },
               },
             },
@@ -187,12 +186,94 @@ describe('SagemakerProjectL3Construct', () => {
     });
 
     const template = Template.fromStack(testApp.testStack);
-    // Verify exactly one project profile is created (no duplicate resource)
-    template.resourceCountIs('AWS::DataZone::ProjectProfile', 1);
-    // Verify the profile exists with expected name
     template.hasResourceProperties('AWS::DataZone::ProjectProfile', {
-      Name: 'test-profile-merge',
-      Status: 'ENABLED',
+      Name: 'test-profile-merge-1',
+      EnvironmentConfigurations: Match.arrayWith([
+        Match.objectLike({
+          Name: 'Tooling',
+          ConfigurationParameters: {
+            ParameterOverrides: Match.arrayWith([
+              Match.objectLike({ Name: 'CustomParam', Value: 'tooling-user-value' }),
+            ]),
+          },
+        }),
+      ]),
+    });
+  });
+
+  it('should let compliance overrides win on name collision with user overrides', () => {
+    new SagemakerProjectL3Construct(testApp.testStack, 'test-sm-merge-2', {
+      naming: testApp.naming,
+      roleHelper,
+      domainConfig,
+      projectProfiles: {
+        'test-profile-merge-2': {
+          environments: {
+            Tooling: {
+              parameters: {
+                overrides: {
+                  enableNetworkIsolation: { value: 'false', isEditable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const template = Template.fromStack(testApp.testStack);
+    template.hasResourceProperties('AWS::DataZone::ProjectProfile', {
+      Name: 'test-profile-merge-2',
+      EnvironmentConfigurations: Match.arrayWith([
+        Match.objectLike({
+          Name: 'Tooling',
+          ConfigurationParameters: {
+            ParameterOverrides: Match.arrayWith([
+              Match.objectLike({
+                Name: 'enableNetworkIsolation',
+                Value: 'true',
+                IsEditable: false,
+              }),
+            ]),
+          },
+        }),
+      ]),
+    });
+  });
+
+  it('should merge user ParameterOverrides into DataLake environment identically', () => {
+    new SagemakerProjectL3Construct(testApp.testStack, 'test-sm-merge-3', {
+      naming: testApp.naming,
+      roleHelper,
+      domainConfig,
+      projectProfiles: {
+        'test-profile-merge-3': {
+          environments: {
+            DataLake: {
+              parameters: {
+                overrides: {
+                  DataLakeParam: { value: 'datalake-value' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const template = Template.fromStack(testApp.testStack);
+    template.hasResourceProperties('AWS::DataZone::ProjectProfile', {
+      Name: 'test-profile-merge-3',
+      EnvironmentConfigurations: Match.arrayWith([
+        Match.objectLike({
+          Name: 'DataLake',
+          ConfigurationParameters: {
+            ParameterOverrides: Match.arrayWith([
+              Match.objectLike({ Name: 'DataLakeParam', Value: 'datalake-value' }),
+            ]),
+          },
+        }),
+      ]),
     });
   });
 });

--- a/packages/constructs/L3/governance/sagemaker-project-l3-construct/test/sagemaker-project.test.ts
+++ b/packages/constructs/L3/governance/sagemaker-project-l3-construct/test/sagemaker-project.test.ts
@@ -164,4 +164,35 @@ describe('SagemakerProjectL3Construct', () => {
     const template = Template.fromStack(testApp.testStack);
     template.resourceCountIs('AWS::DataZone::Project', 1);
   });
+
+  it('should merge user Tooling/DataLake param overrides without duplicates', () => {
+    new SagemakerProjectL3Construct(testApp.testStack, 'test-sm-construct-dup', {
+      naming: testApp.naming,
+      roleHelper,
+      domainConfig,
+      projectProfiles: {
+        'test-profile-merge': {
+          environments: {
+            DefaultDataLake: {},
+            Tooling: {
+              parameters: {
+                overrides: {
+                  CustomParam: { value: 'user-value' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const template = Template.fromStack(testApp.testStack);
+    // Verify exactly one project profile is created (no duplicate resource)
+    template.resourceCountIs('AWS::DataZone::ProjectProfile', 1);
+    // Verify the profile exists with expected name
+    template.hasResourceProperties('AWS::DataZone::ProjectProfile', {
+      Name: 'test-profile-merge',
+      Status: 'ENABLED',
+    });
+  });
 });


### PR DESCRIPTION
Fixes #40

When a user specifies `Tooling` or `DataLake` under `environments` in a project profile config (to override blueprint parameters like `enableAthena`), CloudFormation fails with:

```
Duplicate name found Tooling (Service: DataZone, Status Code: 400)
```

**Root cause:** `createProjectProfile()` builds `envConfigs` from user input (which may include Tooling/DataLake entries), then unconditionally prepends hard-coded `toolingEnvConfig` and `datalakeEnvConfig` — creating duplicates.

**Fix:** Extract user Tooling/DataLake entries from `envConfigs`, merge their `parameterOverrides` into the hard-coded configs (compliance overrides always win on name collision via Map deduplication), and exclude them from the final array.

**Test added:** Verifies that a project profile with user-supplied Tooling parameter overrides produces exactly one `AWS::DataZone::ProjectProfile` resource (no duplicates).