### PR TITLE
fix(datazone): add Bedrock KMS authorization for tooling key and provisioning role

### DIFF
--- a/packages/apps/core/app/test/app.test.ts
+++ b/packages/apps/core/app/test/app.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 import { MdaaAppProps, MdaaCdkApp } from '../lib/app';
 import { MdaaL3ConstructProps } from '@aws-mdaa/l3-construct';
 import { MdaaAppConfigParserProps, MdaaSageMakerCustomBluePrintConfig } from '../lib/app_config';

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-2-test-region.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-2-test-region.baseline.json
@@ -1086,10 +1086,16 @@
               "Sid": "DomainKmsCreateGrant"
             },
             {
-              "Action": "kms:CreateGrant",
+              "Action": [
+                "kms:CreateGrant",
+                "kms:RetireGrant"
+              ],
               "Condition": {
-                "StringLike": {
+                "StringEquals": {
                   "kms:CallerAccount": "test-account-2"
+                },
+                "Bool": {
+                  "kms:GrantIsForAWSResource": "true"
                 }
               },
               "Effect": "Allow",
@@ -1823,6 +1829,30 @@
               },
               "Resource": "*",
               "Sid": "CloudWatchLogsEncryption"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncryptFrom",
+                "kms:ReEncryptTo",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "test-account-2"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock.amazonaws.com"
+              },
+              "Resource": "*",
+              "Sid": "BedrockEncryption"
             }
           ],
           "Version": "2012-10-17"

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-3-test-region.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-3-test-region.baseline.json
@@ -1081,10 +1081,16 @@
               "Sid": "DomainKmsCreateGrant"
             },
             {
-              "Action": "kms:CreateGrant",
+              "Action": [
+                "kms:CreateGrant",
+                "kms:RetireGrant"
+              ],
               "Condition": {
-                "StringLike": {
+                "StringEquals": {
                   "kms:CallerAccount": "test-account-3"
+                },
+                "Bool": {
+                  "kms:GrantIsForAWSResource": "true"
                 }
               },
               "Effect": "Allow",
@@ -1653,6 +1659,30 @@
               },
               "Resource": "*",
               "Sid": "CloudWatchLogsEncryption"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncryptFrom",
+                "kms:ReEncryptTo",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "test-account-3"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock.amazonaws.com"
+              },
+              "Resource": "*",
+              "Sid": "BedrockEncryption"
             }
           ],
           "Version": "2012-10-17"

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main.baseline.json
@@ -7764,6 +7764,9 @@
             "Ref": "datazonedomainkmsmanagedpolicytestdomainDBE6529E"
           },
           {
+            "Ref": "datazonedomainkmsadminpolicytestdomain95C34EBC"
+          },
+          {
             "Ref": "datazonedomainbucketmanagedpolicytestdomainC3171E05"
           }
         ],
@@ -7994,6 +7997,30 @@
               },
               "Resource": "*",
               "Sid": "CloudWatchLogsEncryption"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncryptFrom",
+                "kms:ReEncryptTo",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "test-account"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock.amazonaws.com"
+              },
+              "Resource": "*",
+              "Sid": "BedrockEncryption"
             }
           ],
           "Version": "2012-10-17"
@@ -9662,10 +9689,16 @@
               "Sid": "DomainKmsCreateGrant"
             },
             {
-              "Action": "kms:CreateGrant",
+              "Action": [
+                "kms:CreateGrant",
+                "kms:RetireGrant"
+              ],
               "Condition": {
-                "StringLike": {
+                "StringEquals": {
                   "kms:CallerAccount": "test-account"
+                },
+                "Bool": {
+                  "kms:GrantIsForAWSResource": "true"
                 }
               },
               "Effect": "Allow",

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-sagemaker-minimal.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-sagemaker-minimal.baseline.json
@@ -1108,6 +1108,9 @@
             "Ref": "datazonedomainkmsmanagedpolicytestdomainDBE6529E"
           },
           {
+            "Ref": "datazonedomainkmsadminpolicytestdomain95C34EBC"
+          },
+          {
             "Ref": "datazonedomainbucketmanagedpolicytestdomainC3171E05"
           }
         ],
@@ -1338,6 +1341,30 @@
               },
               "Resource": "*",
               "Sid": "CloudWatchLogsEncryption"
+            },
+            {
+              "Action": [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncryptFrom",
+                "kms:ReEncryptTo",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateDataKeyPair",
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "test-account"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock.amazonaws.com"
+              },
+              "Resource": "*",
+              "Sid": "BedrockEncryption"
             }
           ],
           "Version": "2012-10-17"
@@ -2312,10 +2339,16 @@
               "Sid": "DomainKmsCreateGrant"
             },
             {
-              "Action": "kms:CreateGrant",
+              "Action": [
+                "kms:CreateGrant",
+                "kms:RetireGrant"
+              ],
               "Condition": {
-                "StringLike": {
+                "StringEquals": {
                   "kms:CallerAccount": "test-account"
+                },
+                "Bool": {
+                  "kms:GrantIsForAWSResource": "true"
                 }
               },
               "Effect": "Allow",

--- a/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
+++ b/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 /* eslint-disable jest/expect-expect */
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';

--- a/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
@@ -390,6 +390,8 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
       domainName,
     );
     domainDefaultBlueprintProvisioningRole.addManagedPolicy(policies.domainKmsUsagePolicy);
+    // kms:CreateGrant required so the Bedrock CF resource handler can create service grants on the tooling key
+    domainDefaultBlueprintProvisioningRole.addManagedPolicy(policies.domainKmsAdminPolicy);
     domainDefaultBlueprintProvisioningRole.addManagedPolicy(policies.domainBucketUsagePolicy);
 
     const toolingProvisioningRole = domainProps.tooling.provisioningRole
@@ -689,10 +691,13 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
         sid: 'ToolingKmsCreateGrant',
         effect: Effect.ALLOW,
         resources: [kmsKey.keyArn],
-        actions: ['kms:CreateGrant'],
+        actions: ['kms:CreateGrant', 'kms:RetireGrant'],
         conditions: {
-          StringLike: {
+          StringEquals: {
             'kms:CallerAccount': account,
+          },
+          Bool: {
+            'kms:GrantIsForAWSResource': 'true',
           },
         },
       }),
@@ -714,6 +719,27 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
       },
     });
     kmsKey.addToResourcePolicy(cloudwatchStatement);
+
+    // The AmazonBedrockGuardrail (and other Bedrock) blueprints create resources encrypted with
+    // this KMS key. Bedrock calls kms:GenerateDataKey / kms:Decrypt as the bedrock service
+    // principal on behalf of the provisioning role. Without this grant the CreateGuardrail CF
+    // resource handler fails with "You don't have sufficient permissions for this KMS key."
+    // aws:SourceAccount scopes the grant to this account. aws:SourceArn is not added because
+    // Bedrock does not consistently populate it for all resource types (Guardrails, KnowledgeBases,
+    // Agents, etc.), and a condition that is never present would silently deny all Bedrock calls.
+    const bedrockStatement = new PolicyStatement({
+      sid: 'BedrockEncryption',
+      effect: Effect.ALLOW,
+      actions: [...DECRYPT_ACTIONS, ...ENCRYPT_ACTIONS, 'kms:DescribeKey'],
+      principals: [new ServicePrincipal('bedrock.amazonaws.com')],
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'aws:SourceAccount': account,
+        },
+      },
+    });
+    kmsKey.addToResourcePolicy(bedrockStatement);
 
     const toolingBucket = new MdaaBucket(scope, `${domainName}-tooling-bucket`, {
       naming: this.props.naming,

--- a/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
@@ -5,7 +5,7 @@
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';
 import { MdaaTestApp } from '@aws-mdaa/testing';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Stack } from 'aws-cdk-lib';
 import { DataZoneL3Construct, DataZoneL3ConstructProps } from '../lib';
 
@@ -2624,6 +2624,89 @@ describe('DataZone L3 Construct Tests', () => {
       // Should create blueprint configurations for non-Tooling blueprints
       const blueprintConfigs = template.findResources('AWS::DataZone::EnvironmentBlueprintConfiguration');
       expect(Object.keys(blueprintConfigs).length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('tooling KMS key includes BedrockEncryption statement for bedrock.amazonaws.com', () => {
+      new DataZoneL3Construct(stack, 'test-bedrock-kms', {
+        roleHelper,
+        naming: testApp.naming,
+        lakeformationManageAccessRole: { arn: 'arn:test-partition:iam::123456789012:role/test-role' },
+        sageMakerDomains: {
+          'test-domain': {
+            description: 'Test domain',
+            dataAdminRole: { name: 'admin' },
+            userAssignment: 'MANUAL',
+            tooling: {
+              vpcId: 'test-vpc',
+              subnetIds: ['subnet-id-1'],
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      // Bedrock blueprint environments (e.g. AmazonBedrockGuardrail) call kms:GenerateDataKey /
+      // kms:Decrypt as bedrock.amazonaws.com when creating CMK-encrypted resources. Without this
+      // statement the CF resource handler fails with AccessDenied on the key policy.
+      template.hasResourceProperties('AWS::KMS::Key', {
+        KeyPolicy: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'BedrockEncryption',
+              Effect: 'Allow',
+              Principal: { Service: 'bedrock.amazonaws.com' },
+              Action: Match.arrayWith(['kms:Decrypt', 'kms:GenerateDataKey', 'kms:DescribeKey']),
+              Condition: {
+                StringEquals: { 'aws:SourceAccount': Match.anyValue() },
+              },
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('default provisioning role has kms:CreateGrant (kms-admin policy) attached', () => {
+      // Use tooling without an explicit provisioningRole to exercise domainDefaultBlueprintProvisioningRole.
+      // kms:CreateGrant is required so the Bedrock CF resource handler can create a service grant
+      // allowing bedrock.amazonaws.com to use the tooling key for CMK-encrypted resource operations.
+      new DataZoneL3Construct(stack, 'test-provisioning-kms-admin', {
+        roleHelper,
+        naming: testApp.naming,
+        lakeformationManageAccessRole: { arn: 'arn:test-partition:iam::123456789012:role/test-role' },
+        sageMakerDomains: {
+          'test-domain': {
+            description: 'Test domain',
+            dataAdminRole: { name: 'admin' },
+            userAssignment: 'MANUAL',
+            tooling: {
+              vpcId: 'test-vpc',
+              subnetIds: ['subnet-id-1'],
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      // Locate the kms-admin managed policy by its ToolingKmsCreateGrant statement.
+      const kmsAdminPolicies = template.findResources('AWS::IAM::ManagedPolicy', {
+        Properties: {
+          PolicyDocument: {
+            Statement: Match.arrayWith([
+              Match.objectLike({
+                Sid: 'ToolingKmsCreateGrant',
+                Action: Match.arrayWith(['kms:CreateGrant', 'kms:RetireGrant']),
+              }),
+            ]),
+          },
+        },
+      });
+      const kmsAdminPolicyLogicalIds = Object.keys(kmsAdminPolicies);
+      expect(kmsAdminPolicyLogicalIds.length).toBeGreaterThanOrEqual(1);
+
+      // The default provisioning role must reference this policy in its ManagedPolicyArns.
+      template.hasResourceProperties('AWS::IAM::Role', {
+        ManagedPolicyArns: Match.arrayWith([Match.objectLike({ Ref: kmsAdminPolicyLogicalIds[0] })]),
+      });
     });
 
     test('should throw if Tooling/DataLake are in enabledManagedBlueprints', () => {


### PR DESCRIPTION
*Issue #, if available:* #46 

Addresses three gaps in the KMS authorization chain preventing Bedrock blueprint environments (AmazonBedrockGuardrail, AmazonBedrockKnowledgeBase, etc.) from deploying

*Description of changes:*

1. The tooling KMS key policy lacked a `bedrock.amazonaws.com` principal statement. Bedrock calls `kms:GenerateDataKey`/`kms:Decrypt`/`kms:DescribeKey` as a service principal when creating CMK-encrypted resources; without this grant the CF resource handler fails with `AccessDeniedException`. Scoped to the domain account via `aws:SourceAccount`.

2. The `ToolingKmsCreateGrant` statement in `domainKmsAdminPolicy` was incomplete: `kms:RetireGrant` was missing (so CF cannot retire grants on resource deletion), the condition used `StringLike` instead of `StringEquals` for `kms:CallerAccount` (semantically imprecise for an exact-match), and `kms:GrantIsForAWSResource` was absent (allowing arbitrary non-service grants on the tooling key).

3. The default blueprint provisioning role (`domainDefaultBlueprintProvisioningRole`) was not attached to the kms-admin managed policy, so `kms:CreateGrant` was denied at IAM evaluation before the key policy was consulted. The cross-account provisioning role already had this attachment; the primary account path did not.

Tests:
- `datazone-l3-construct.test.ts`: assert BedrockEncryption statement on tooling key and kms-admin policy attachment on the default provisioning role
- `app.test.ts` and `sm-studio-domain.test.ts`: Lambda/Docker mocks to prevent test failures in environments without a Docker daemon


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.