### PR TITLE
fix(datazone): correct CloudWatch Logs KMS condition operator and scope

### DIFF
--- a/packages/apps/core/app/test/app.test.ts
+++ b/packages/apps/core/app/test/app.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 import { MdaaAppProps, MdaaCdkApp } from '../lib/app';
 import { MdaaL3ConstructProps } from '@aws-mdaa/l3-construct';
 import { MdaaAppConfigParserProps, MdaaSageMakerCustomBluePrintConfig } from '../lib/app_config';

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-2-test-region.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-2-test-region.baseline.json
@@ -1807,13 +1807,15 @@
                 "kms:GenerateDataKey",
                 "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:GenerateDataKeyPair",
-                "kms:GenerateDataKeyPairWithoutPlaintext"
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
               ],
               "Condition": {
-                "ArnEquals": {
+                "ArnLike": {
                   "kms:EncryptionContext:aws:logs:arn": [
                     "arn:test-partition:logs:test-region:test-account-2:log-group:datazone-*",
-                    "arn:test-partition:logs:test-region:test-account-2:log-group:airflow-*"
+                    "arn:test-partition:logs:test-region:test-account-2:log-group:airflow-*",
+                    "arn:test-partition:logs:test-region:test-account-2:log-group:/aws/lambda/amazon-bedrock-ide-*"
                   ]
                 }
               },

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-3-test-region.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main-test-account-3-test-region.baseline.json
@@ -1637,13 +1637,15 @@
                 "kms:GenerateDataKey",
                 "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:GenerateDataKeyPair",
-                "kms:GenerateDataKeyPairWithoutPlaintext"
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
               ],
               "Condition": {
-                "ArnEquals": {
+                "ArnLike": {
                   "kms:EncryptionContext:aws:logs:arn": [
                     "arn:test-partition:logs:test-region:test-account-3:log-group:datazone-*",
-                    "arn:test-partition:logs:test-region:test-account-3:log-group:airflow-*"
+                    "arn:test-partition:logs:test-region:test-account-3:log-group:airflow-*",
+                    "arn:test-partition:logs:test-region:test-account-3:log-group:/aws/lambda/amazon-bedrock-ide-*"
                   ]
                 }
               },

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-sagemaker-main.baseline.json
@@ -7978,13 +7978,15 @@
                 "kms:GenerateDataKey",
                 "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:GenerateDataKeyPair",
-                "kms:GenerateDataKeyPairWithoutPlaintext"
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
               ],
               "Condition": {
-                "ArnEquals": {
+                "ArnLike": {
                   "kms:EncryptionContext:aws:logs:arn": [
                     "arn:test-partition:logs:test-region:test-account:log-group:datazone-*",
-                    "arn:test-partition:logs:test-region:test-account:log-group:airflow-*"
+                    "arn:test-partition:logs:test-region:test-account:log-group:airflow-*",
+                    "arn:test-partition:logs:test-region:test-account:log-group:/aws/lambda/amazon-bedrock-ide-*"
                   ]
                 }
               },

--- a/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-sagemaker-minimal.baseline.json
+++ b/packages/apps/governance/sagemaker-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-sagemaker-minimal.baseline.json
@@ -1322,13 +1322,15 @@
                 "kms:GenerateDataKey",
                 "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:GenerateDataKeyPair",
-                "kms:GenerateDataKeyPairWithoutPlaintext"
+                "kms:GenerateDataKeyPairWithoutPlaintext",
+                "kms:DescribeKey"
               ],
               "Condition": {
-                "ArnEquals": {
+                "ArnLike": {
                   "kms:EncryptionContext:aws:logs:arn": [
                     "arn:test-partition:logs:test-region:test-account:log-group:datazone-*",
-                    "arn:test-partition:logs:test-region:test-account:log-group:airflow-*"
+                    "arn:test-partition:logs:test-region:test-account:log-group:airflow-*",
+                    "arn:test-partition:logs:test-region:test-account:log-group:/aws/lambda/amazon-bedrock-ide-*"
                   ]
                 }
               },

--- a/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
+++ b/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 /* eslint-disable jest/expect-expect */
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';

--- a/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
@@ -701,14 +701,15 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
     const cloudwatchStatement = new PolicyStatement({
       sid: 'CloudWatchLogsEncryption',
       effect: Effect.ALLOW,
-      actions: [...DECRYPT_ACTIONS, ...ENCRYPT_ACTIONS],
+      actions: [...DECRYPT_ACTIONS, ...ENCRYPT_ACTIONS, 'kms:DescribeKey'],
       principals: [new ServicePrincipal(`logs.${this.props.region}.amazonaws.com`)],
       resources: ['*'],
       conditions: {
-        ArnEquals: {
+        ArnLike: {
           'kms:EncryptionContext:aws:logs:arn': [
             `arn:${this.props.partition}:logs:${region}:${account}:log-group:datazone-*`,
             `arn:${this.props.partition}:logs:${region}:${account}:log-group:airflow-*`,
+            `arn:${this.props.partition}:logs:${region}:${account}:log-group:/aws/lambda/amazon-bedrock-ide-*`,
           ],
         },
       },

--- a/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
@@ -5,7 +5,7 @@
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';
 import { MdaaTestApp } from '@aws-mdaa/testing';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Stack } from 'aws-cdk-lib';
 import { DataZoneL3Construct, DataZoneL3ConstructProps } from '../lib';
 
@@ -2624,6 +2624,48 @@ describe('DataZone L3 Construct Tests', () => {
       // Should create blueprint configurations for non-Tooling blueprints
       const blueprintConfigs = template.findResources('AWS::DataZone::EnvironmentBlueprintConfiguration');
       expect(Object.keys(blueprintConfigs).length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('tooling KMS key CloudWatchLogsEncryption statement uses ArnLike with specific log group prefixes', () => {
+      new DataZoneL3Construct(stack, 'test-cw-logs-condition', {
+        roleHelper,
+        naming: testApp.naming,
+        lakeformationManageAccessRole: { arn: 'arn:test-partition:iam::123456789012:role/test-role' },
+        sageMakerDomains: {
+          'test-domain': {
+            description: 'Test domain',
+            dataAdminRole: { name: 'admin' },
+            userAssignment: 'MANUAL',
+            tooling: {
+              vpcId: 'test-vpc',
+              subnetIds: ['subnet-id-1'],
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties('AWS::KMS::Key', {
+        KeyPolicy: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'CloudWatchLogsEncryption',
+              Effect: 'Allow',
+              Principal: { Service: Match.stringLikeRegexp('logs\\..*\\.amazonaws\\.com') },
+              Action: Match.arrayWith(['kms:DescribeKey']),
+              Condition: {
+                ArnLike: {
+                  'kms:EncryptionContext:aws:logs:arn': Match.arrayWith([
+                    Match.stringLikeRegexp(':log-group:datazone-'),
+                    Match.stringLikeRegexp(':log-group:airflow-'),
+                    Match.stringLikeRegexp(':log-group:/aws/lambda/amazon-bedrock-ide-'),
+                  ]),
+                },
+              },
+            }),
+          ]),
+        },
+      });
     });
 
     test('should throw if Tooling/DataLake are in enabledManagedBlueprints', () => {


### PR DESCRIPTION
*Issue #, if available:* #48

*Description of changes:*

Two compounding issues caused `AmazonBedrockKnowledgeBase` environment deployment in SMUS to fail with "The specified KMS key does not exist or is not allowed to be used":

1. `ArnEquals` was used instead of `ArnLike`. `ArnEquals` treats '*' as a literal character, so the wildcard suffixes in the original two ARN prefixes never matched any real log group ARN.

2. The two hardcoded prefixes (`datazone-*`, `airflow-*`) did not cover Bedrock Lambda log groups created by `AmazonBedrockKnowledgeBase` (`/aws/lambda/amazon-bedrock-ide-kbIngestion--*` and `opensearchIndex--*`).

Fix: switch to `ArnLike` and add the Bedrock Lambda log group prefix as a third entry alongside the existing `datazone-*` and `airflow-*` prefixes. Also adds `kms:DescribeKey`, which CloudWatch Logs requires to verify the key before use.

Tests:
- `datazone-l3-construct.test.ts`: assert `CloudWatchLogsEncryption` uses ArnLike with all three expected log group prefixes and `kms:DescribeKey`
- `app.test.ts` and `sm-studio-domain.test.ts`: Lambda/Docker mocks to prevent test failures in environments without a Docker daemon

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
