### PR TITLE
fix(datazone): pre-create AOSS encryption policy with correct wildcard for Bedrock IDE collections

### DIFF
--- a/packages/apps/core/app/test/app.test.ts
+++ b/packages/apps/core/app/test/app.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 import { MdaaAppProps, MdaaCdkApp } from '../lib/app';
 import { MdaaL3ConstructProps } from '@aws-mdaa/l3-construct';
 import { MdaaAppConfigParserProps, MdaaSageMakerCustomBluePrintConfig } from '../lib/app_config';

--- a/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
+++ b/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 /* eslint-disable jest/expect-expect */
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';

--- a/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/lib/private/sagemaker-domain-helper.ts
@@ -16,9 +16,10 @@ import {
 import { MdaaManagedPolicy, MdaaRole } from '@aws-mdaa/iam-constructs';
 import { DECRYPT_ACTIONS, ENCRYPT_ACTIONS, MdaaKmsKey, USER_ACTIONS } from '@aws-mdaa/kms-constructs';
 import { MdaaBucket } from '@aws-mdaa/s3-constructs';
-import { Stack } from 'aws-cdk-lib';
+import { Fn, Stack } from 'aws-cdk-lib';
 
 import { CfnDomain, CfnEnvironmentBlueprintConfiguration, CfnUserProfile } from 'aws-cdk-lib/aws-datazone';
+import { CfnSecurityPolicy } from 'aws-cdk-lib/aws-opensearchserverless';
 import {
   ArnPrincipal,
   Conditions,
@@ -406,6 +407,7 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
       domainProps.tooling,
       policies.domainKmsUsagePolicy,
       policies.domainKmsAdminPolicy,
+      domainResources.domain.attrId,
     );
     const toolingParams = { ...domainProps.tooling?.parameterValues, ...toolingResourceParams };
 
@@ -670,6 +672,7 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
     toolingProps: ToolingBlueprintProps,
     domainKmsUsagePolicy: ManagedPolicy,
     domainKmsAdminPolicy: ManagedPolicy,
+    domainId?: string,
   ): { [paramName: string]: string } {
     const kmsKey = new MdaaKmsKey(scope, `${domainName}-tooling-kms`, {
       naming: this.props.naming,
@@ -722,6 +725,21 @@ export class SageMakerDomainHelper extends CommonDomainHelper {
       createParams: false,
       createOutputs: false,
     });
+
+    // DataZone auto-creates this policy at domain setup time with a broken resource pattern
+    // that never matches actual collection names. Pre-creating it here prevents that.
+    if (domainId) {
+      const domainIdSuffix = Fn.select(1, Fn.split('dzd-', domainId));
+      new CfnSecurityPolicy(scope, `${domainName}-bedrock-ide-aoss-encryption`, {
+        name: Fn.join('', ['bedrock-ide-', domainIdSuffix]),
+        type: 'encryption',
+        policy: Stack.of(scope).toJsonString({
+          Rules: [{ Resource: ['collection/bedrock-ide-*'], ResourceType: 'collection' }],
+          AWSOwnedKey: false,
+          KmsARN: kmsKey.keyArn,
+        }),
+      });
+    }
 
     const forcedParams = {
       KmsKeyArn: kmsKey.keyArn,

--- a/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
+++ b/packages/constructs/L3/governance/datazone-l3-construct/test/datazone-l3-construct.test.ts
@@ -5,7 +5,7 @@
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';
 import { MdaaTestApp } from '@aws-mdaa/testing';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Stack } from 'aws-cdk-lib';
 import { DataZoneL3Construct, DataZoneL3ConstructProps } from '../lib';
 
@@ -2811,6 +2811,34 @@ describe('DataZone L3 Construct Tests', () => {
 
       // data-admin (2) + Tooling/DataLake blueprint auths (2) + custom-resource-role-auth (1) = 5
       template.resourceCountIs('AWS::DataZone::PolicyGrant', 5);
+    });
+
+    test('AOSS encryption policy is pre-created with broad collection/bedrock-ide-* pattern', () => {
+      new DataZoneL3Construct(stack, 'test-aoss-policy', {
+        roleHelper,
+        naming: testApp.naming,
+        lakeformationManageAccessRole: { arn: 'arn:test-partition:iam::123456789012:role/test-role' },
+        sageMakerDomains: {
+          'test-domain': {
+            description: 'Test domain',
+            dataAdminRole: { name: 'admin' },
+            userAssignment: 'MANUAL',
+            tooling: {
+              vpcId: 'test-vpc',
+              subnetIds: ['subnet-id-1'],
+            },
+          },
+        },
+      });
+      const template = Template.fromStack(stack);
+
+      template.resourceCountIs('AWS::OpenSearchServerless::SecurityPolicy', 1);
+      template.hasResourceProperties('AWS::OpenSearchServerless::SecurityPolicy', {
+        Type: 'encryption',
+        Policy: Match.objectLike({
+          'Fn::Join': Match.arrayWith([Match.arrayWith([Match.stringLikeRegexp('collection/bedrock-ide-\\*')])]),
+        }),
+      });
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:* #50

*Description of changes:*

DataZone auto-creates an AOSS encryption security policy at domain setup time using a resource pattern derived from a numeric prefix of the domain ID (e.g. `collection/bedrock-ide-634-*`). This pattern never matches actual per-environment collection names (`bedrock-ide-<env-id>`), causing every `AmazonBedrockKnowledgeBase` environment to fail with:
  "No matching security policy of encryption type found for collection name: bedrock-ide-<env-id>"

Fix: pre-create the policy in CDK with the same name DataZone would generate but with the correct broad pattern `collection/bedrock-ide-*`. DataZone detects the pre-existing policy and skips creating a broken replacement.

Only applied from the primary-account call path (domainId is available there). Cross-account tooling stacks omit domainId deliberately -- DataZone manages AOSS policies for associated accounts separately.

Tests:
- `datazone-l3-construct.test.ts`: assert AOSS encryption policy is pre-created with type encryption and resource pattern matching `collection/bedrock-ide-*`
- `app.test.ts` and `sm-studio-domain.test.ts`: Lambda/Docker mocks to prevent test failures in environments without a Docker daemon

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
