### PR TITLE
fix(dataops-job): apply AmazonDataZoneProject tag so Glue jobs appear in SMUS UI

### DIFF
--- a/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-comprehensive.baseline.json
+++ b/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-comprehensive.baseline.json
@@ -25,6 +25,10 @@
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/test-org/test-domain/dataops-project-test/kmsArn/default"
     },
+    "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/test-org/test-domain/dataops-project-test/sagemaker/project/id/default"
+    },
     "BootstrapVersion": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -551,6 +555,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -1406,6 +1413,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -2183,6 +2193,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -2609,6 +2622,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -3221,6 +3237,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",

--- a/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-minimal.baseline.json
+++ b/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-minimal.baseline.json
@@ -25,6 +25,10 @@
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/test-org/test-domain/dataops-project-test/kmsArn/default"
     },
+    "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/test-org/test-domain/dataops-project-test/sagemaker/project/id/default"
+    },
     "BootstrapVersion": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -392,6 +396,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",

--- a/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-workertype.baseline.json
+++ b/packages/apps/dataops/dataops-job-app/test/__snapshots__/sample-config-workertype.baseline.json
@@ -25,6 +25,10 @@
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/test-org/test-domain/dataops-project-test/kmsArn/default"
     },
+    "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Type": "AWS::SSM::Parameter::Value<String>",
+      "Default": "/test-org/test-domain/dataops-project-test/sagemaker/project/id/default"
+    },
     "BootstrapVersion": {
       "Type": "AWS::SSM::Parameter::Value<String>",
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -392,6 +396,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -820,6 +827,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",
@@ -1248,6 +1258,9 @@
           "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsecurityConfigurationdefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
         },
         "Tags": {
+          "AmazonDataZoneProject": {
+            "Ref": "SsmParameterValuetestorgtestdomaindataopsprojecttestsagemakerprojectiddefaultC96584B6F00A464EAD1953AFF4B05118Parameter"
+          },
           "mdaa_cdk_app": "dataops-job",
           "mdaa_domain": "test-domain",
           "mdaa_env": "test-env",

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-dataops-project-comprehensive.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-dataops-project-comprehensive.baseline.json
@@ -6225,6 +6225,26 @@
         }
       }
     },
+    "ssmsagemakerprojectidFE5981B8": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Name": "/test-org/test-domain/test-dataops-project-comprehensive/sagemaker/project/id/default",
+        "Tags": {
+          "mdaa_cdk_app": "dataops-project",
+          "mdaa_domain": "test-domain",
+          "mdaa_env": "test-env",
+          "mdaa_module_name": "test-dataops-project-comprehensive",
+          "mdaa_org": "test-org"
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "constructsagemakerprojectdataopsproject7423C7DC",
+            "Id"
+          ]
+        }
+      }
+    },
     "securityconfig6DD90031": {
       "Type": "AWS::Glue::SecurityConfiguration",
       "Properties": {

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-datazone.test-org-test-env-test-domain-test-dataops-project-datazone.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-datazone.test-org-test-env-test-domain-test-dataops-project-datazone.baseline.json
@@ -4198,6 +4198,26 @@
         }
       }
     },
+    "ssmsagemakerprojectidFE5981B8": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Name": "/test-org/test-domain/test-dataops-project-datazone/sagemaker/project/id/default",
+        "Tags": {
+          "mdaa_cdk_app": "dataops-project",
+          "mdaa_domain": "test-domain",
+          "mdaa_env": "test-env",
+          "mdaa_module_name": "test-dataops-project-datazone",
+          "mdaa_org": "test-org"
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "constructdatazoneproject5CD687B2",
+            "Id"
+          ]
+        }
+      }
+    },
     "securityconfig6DD90031": {
       "Type": "AWS::Glue::SecurityConfiguration",
       "Properties": {

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-sagemaker.test-org-test-env-test-domain-test-dataops-project-sagemaker.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-sagemaker.test-org-test-env-test-domain-test-dataops-project-sagemaker.baseline.json
@@ -4227,6 +4227,26 @@
         }
       }
     },
+    "ssmsagemakerprojectidFE5981B8": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Name": "/test-org/test-domain/test-dataops-project-sagemaker/sagemaker/project/id/default",
+        "Tags": {
+          "mdaa_cdk_app": "dataops-project",
+          "mdaa_domain": "test-domain",
+          "mdaa_env": "test-env",
+          "mdaa_module_name": "test-dataops-project-sagemaker",
+          "mdaa_org": "test-org"
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "constructsagemakerprojectdataopsproject7423C7DC",
+            "Id"
+          ]
+        }
+      }
+    },
     "securityconfig6DD90031": {
       "Type": "AWS::Glue::SecurityConfiguration",
       "Properties": {

--- a/packages/constructs/L3/dataops/dataops-job-l3-construct/lib/dataops-job-l3-construct.ts
+++ b/packages/constructs/L3/dataops/dataops-job-l3-construct/lib/dataops-job-l3-construct.ts
@@ -10,14 +10,14 @@ import { MdaaRole } from '@aws-mdaa/iam-constructs';
 import { MdaaBucket } from '@aws-mdaa/s3-constructs';
 import { MdaaL3Construct, MdaaL3ConstructProps } from '@aws-mdaa/l3-construct';
 import { CfnJob } from 'aws-cdk-lib/aws-glue';
+import { Fn, Tags } from 'aws-cdk-lib';
+import { MdaaNagSuppressions, MdaaStringParameter } from '@aws-mdaa/construct'; //NOSONAR
 import { BucketDeployment, ISource, Source } from 'aws-cdk-lib/aws-s3-deployment';
-import { MdaaNagSuppressions } from '@aws-mdaa/construct'; //NOSONAR
 import { Construct } from 'constructs';
 import * as path from 'path';
 import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
 import { MdaaSnsTopic } from '@aws-mdaa/sns-constructs';
 import { Rule } from 'aws-cdk-lib/aws-events';
-import { Fn } from 'aws-cdk-lib';
 import { ConfigurationElement } from '@aws-mdaa/config';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { MdaaLogGroup } from '@aws-mdaa/cloudwatch-constructs';
@@ -504,6 +504,16 @@ export class GlueJobL3Construct extends MdaaL3Construct {
         `job/name/${jobName}`,
         job.name,
       );
+
+      // Apply AmazonDataZoneProject tag so the job appears in the SMUS project UI.
+      // The DataZone project ID is published to SSM by the dataops-project module.
+      const projectIdSsmPath = this.props.naming.ssmPath(
+        `${this.props.projectName}/sagemaker/project/id/default`,
+        false,
+        false,
+      );
+      const datazoneProjectId = MdaaStringParameter.valueForStringParameter(this.scope, projectIdSsmPath);
+      Tags.of(job).add('AmazonDataZoneProject', datazoneProjectId);
 
       const eventRule = this.createJobMonitoringEventRule(`${jobName}-monitor`, [job.name]);
       if (!this.props.notificationTopicArn) {

--- a/packages/constructs/L3/dataops/dataops-job-l3-construct/test/job.compliance.test.ts
+++ b/packages/constructs/L3/dataops/dataops-job-l3-construct/test/job.compliance.test.ts
@@ -258,6 +258,11 @@ describe('MDAA Compliance Stack Tests', () => {
         RetentionInDays: Match.absent(),
       });
     });
+    test('Job has AmazonDataZoneProject tag when projectName is set', () => {
+      template.hasResourceProperties('AWS::Glue::Job', {
+        Tags: Match.objectLike({ AmazonDataZoneProject: Match.anyValue() }),
+      });
+    });
   });
 
   describe('MDAA with input parameters', () => {

--- a/packages/constructs/L3/dataops/dataops-project-l3-construct/lib/dataops-project-l3-construct.ts
+++ b/packages/constructs/L3/dataops/dataops-project-l3-construct/lib/dataops-project-l3-construct.ts
@@ -682,12 +682,23 @@ export class DataOpsProjectL3Construct extends MdaaL3Construct {
     if (this.props.datazone && this.props.sagemaker) {
       throw new Error('Only one of datazone or sagemaker properties should be defined');
     }
+    let resources: DatazoneResources | undefined;
     if (this.props.datazone) {
-      return this.createDatazoneResources(this.props.datazone, projectBucket, datazoneUserRole);
+      resources = this.createDatazoneResources(this.props.datazone, projectBucket, datazoneUserRole);
     } else if (this.props.sagemaker) {
-      return this.createSageMakerResources(this.props.sagemaker);
+      resources = this.createSageMakerResources(this.props.sagemaker);
     }
-    return undefined;
+    if (resources?.datazoneProject) {
+      // Publish the DataZone project ID to SSM so sibling modules (dataops-job, dataops-crawler,
+      // dataops-workflow) can apply the AmazonDataZoneProject tag, making their resources visible
+      // in the SageMaker Unified Studio project UI.
+      this.createProjectSSMParam(
+        'ssm-sagemaker-project-id',
+        'sagemaker/project/id/default',
+        resources.datazoneProject.project.attrId,
+      );
+    }
+    return resources;
   }
 
   private createLakeFormationRole() {

--- a/packages/constructs/L3/dataops/dataops-project-l3-construct/test/project.compliance.test.ts
+++ b/packages/constructs/L3/dataops/dataops-project-l3-construct/test/project.compliance.test.ts
@@ -772,6 +772,13 @@ describe('MDAA Compliance Stack Tests', () => {
     });
   });
 
+  test('DataZone project ID SSM parameter published for cross-module use', () => {
+    template.hasResourceProperties('AWS::SSM::Parameter', {
+      Name: Match.stringLikeRegexp('sagemaker/project/id/default'),
+      Type: 'String',
+    });
+  });
+
   test('LakeFormationTagAssociation', () => {
     template.hasResourceProperties('AWS::LakeFormation::TagAssociation', {
       LFTags: [


### PR DESCRIPTION
*Issue #, if available:* #52

*Description of changes:*

Publish the DataZone project ID to SSM from `dataops-project-l3-construct` so sibling modules can apply the `AmazonDataZoneProject` tag at deploy time. Read that SSM value in `dataops-job-l3-construct` and tag each Glue job, making it visible in the SageMaker Unified Studio (**Data analytics → Data processing jobs** section).

Also add compliance and synth test assertions covering the new tag (positive and negative cases) and the new SSM parameter output in the project construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
