### PR TITLE
fix(dataops-project): grant SMUS user role read access to job scripts in project bucket

### DIFF
--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-dataops-project-comprehensive.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-comprehensive.test-org-test-env-test-domain-test-dataops-project-comprehensive.baseline.json
@@ -3742,6 +3742,33 @@
               "Sid": "/temp_ReadWrite"
             },
             {
+              "Action": "s3:GetObject*",
+              "Condition": {
+                "StringLike": {
+                  "aws:PrincipalArn": "arn:aws:iam::test-account:role/datazone_usr_role_*"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "BucketprojectAACC6DD8",
+                        "Arn"
+                      ]
+                    },
+                    "/deployment/*"
+                  ]
+                ]
+              },
+              "Sid": "SmusUserRoleDeploymentRead"
+            },
+            {
               "Action": [
                 "s3:PutObject*",
                 "s3:GetObject*",
@@ -3863,7 +3890,8 @@
                         "projectdeploymentrole542A1AAB",
                         "Arn"
                       ]
-                    }
+                    },
+                    "arn:aws:iam::test-account:role/datazone_usr_role_*"
                   ]
                 }
               },

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-datazone.test-org-test-env-test-domain-test-dataops-project-datazone.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-datazone.test-org-test-env-test-domain-test-dataops-project-datazone.baseline.json
@@ -2313,6 +2313,33 @@
               "Sid": "/temp_ReadWrite"
             },
             {
+              "Action": "s3:GetObject*",
+              "Condition": {
+                "StringLike": {
+                  "aws:PrincipalArn": "arn:aws:iam::test-account:role/datazone_usr_role_*"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "BucketprojectAACC6DD8",
+                        "Arn"
+                      ]
+                    },
+                    "/deployment/*"
+                  ]
+                ]
+              },
+              "Sid": "SmusUserRoleDeploymentRead"
+            },
+            {
               "Action": [
                 "s3:PutObject*",
                 "s3:GetObject*",
@@ -2398,7 +2425,8 @@
                         "projectdeploymentrole542A1AAB",
                         "Arn"
                       ]
-                    }
+                    },
+                    "arn:aws:iam::test-account:role/datazone_usr_role_*"
                   ]
                 }
               },

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-dataops-project-minimal.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-minimal.test-org-test-env-test-domain-test-dataops-project-minimal.baseline.json
@@ -1547,6 +1547,33 @@
               "Sid": "/temp_ReadWrite"
             },
             {
+              "Action": "s3:GetObject*",
+              "Condition": {
+                "StringLike": {
+                  "aws:PrincipalArn": "arn:aws:iam::test-account:role/datazone_usr_role_*"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "BucketprojectAACC6DD8",
+                        "Arn"
+                      ]
+                    },
+                    "/deployment/*"
+                  ]
+                ]
+              },
+              "Sid": "SmusUserRoleDeploymentRead"
+            },
+            {
               "Action": [
                 "s3:PutObject*",
                 "s3:GetObject*",
@@ -1632,7 +1659,8 @@
                         "projectdeploymentrole542A1AAB",
                         "Arn"
                       ]
-                    }
+                    },
+                    "arn:aws:iam::test-account:role/datazone_usr_role_*"
                   ]
                 }
               },

--- a/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-sagemaker.test-org-test-env-test-domain-test-dataops-project-sagemaker.baseline.json
+++ b/packages/apps/dataops/dataops-project-app/test/__snapshots__/sample-config-sagemaker.test-org-test-env-test-domain-test-dataops-project-sagemaker.baseline.json
@@ -1816,6 +1816,33 @@
               "Sid": "/temp_ReadWrite"
             },
             {
+              "Action": "s3:GetObject*",
+              "Condition": {
+                "StringLike": {
+                  "aws:PrincipalArn": "arn:aws:iam::test-account:role/datazone_usr_role_*"
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "BucketprojectAACC6DD8",
+                        "Arn"
+                      ]
+                    },
+                    "/deployment/*"
+                  ]
+                ]
+              },
+              "Sid": "SmusUserRoleDeploymentRead"
+            },
+            {
               "Action": [
                 "s3:PutObject*",
                 "s3:GetObject*",
@@ -1901,7 +1928,8 @@
                         "projectdeploymentrole542A1AAB",
                         "Arn"
                       ]
-                    }
+                    },
+                    "arn:aws:iam::test-account:role/datazone_usr_role_*"
                   ]
                 }
               },

--- a/packages/constructs/L3/dataops/dataops-project-l3-construct/lib/dataops-project-l3-construct.ts
+++ b/packages/constructs/L3/dataops/dataops-project-l3-construct/lib/dataops-project-l3-construct.ts
@@ -1501,12 +1501,25 @@ export class DataOpsProjectL3Construct extends MdaaL3Construct {
     });
     tempPolicy.statements().forEach(statement => projectBucket.addToResourcePolicy(statement));
 
+    // SMUS creates per-user roles named datazone_usr_role_<projectId>_<userId> at session time.
+    // These are not known to MDAA at deploy time so they cannot be added to roleExcludeIds.
+    const smusUserRoleArnPattern = `arn:aws:iam::${this.account}:role/datazone_usr_role_*`;
+    const smusUserRoleDeploymentRead = new PolicyStatement({
+      sid: 'SmusUserRoleDeploymentRead',
+      effect: Effect.ALLOW,
+      actions: RestrictObjectPrefixToRoles.READ_ACTIONS,
+      resources: [projectBucket.arnForObjects('deployment/*')],
+      conditions: { StringLike: { 'aws:PrincipalArn': smusUserRoleArnPattern } },
+    });
+    smusUserRoleDeploymentRead.addAnyPrincipal();
+    projectBucket.addToResourcePolicy(smusUserRoleDeploymentRead);
+
     //Default Deny Policy
     //Any role not specified in props is explicitely denied access to the bucket
     const bucketRestrictPolicy = new RestrictBucketToRoles({
       s3Bucket: projectBucket,
       roleExcludeIds: [...this.getAllRoleIds(), lakeFormationRole.roleId, datazoneUserRole.roleId],
-      principalExcludes: [projectDeploymentRole.roleArn],
+      principalExcludes: [projectDeploymentRole.roleArn, smusUserRoleArnPattern],
     });
     projectBucket.addToResourcePolicy(bucketRestrictPolicy.denyStatement);
     projectBucket.addToResourcePolicy(bucketRestrictPolicy.allowStatement);

--- a/packages/constructs/L3/dataops/dataops-project-l3-construct/test/project.compliance.test.ts
+++ b/packages/constructs/L3/dataops/dataops-project-l3-construct/test/project.compliance.test.ts
@@ -432,6 +432,29 @@ describe('MDAA Compliance Stack Tests', () => {
     });
   });
 
+  test('SmusUserRoleDeploymentRead', () => {
+    template.hasResourceProperties('AWS::S3::BucketPolicy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Sid: 'SmusUserRoleDeploymentRead',
+            Effect: 'Allow',
+            Action: 's3:GetObject*',
+            Principal: { AWS: '*' },
+            Resource: {
+              'Fn::Join': ['', [{ 'Fn::GetAtt': ['BucketprojectAACC6DD8', 'Arn'] }, '/deployment/*']],
+            },
+            Condition: {
+              StringLike: {
+                'aws:PrincipalArn': Match.stringLikeRegexp('datazone_usr_role_\\*$'),
+              },
+            },
+          }),
+        ]),
+      },
+    });
+  });
+
   test('DeploymentRoleReadWrite', () => {
     template.hasResourceProperties('AWS::S3::BucketPolicy', {
       PolicyDocument: {


### PR DESCRIPTION
*Issue #, if available:* #54

*Related issue:* #52

*Description of changes:*

SMUS per-user roles (`datazone_usr_role_<projectId>_<userId>`) are created dynamically by AWS at session time and are unknown to MDAA at deploy time. The project bucket's catch-all deny policy was blocking these roles from reading Glue job scripts under `deployment/*`, causing script load failures when users clicked Script in the SMUS Data Processing Jobs view.

Two changes to `createProjectBucket`:
- Add SmusUserRoleDeploymentRead: Allow s3:GetObject* on deployment/* for any principal matching `arn:aws:iam::<account>:role/datazone_usr_role_*`
- Add the same pattern to `principalExcludes` so the catch-all deny does not fire for SMUS user roles (mirrors the existing dz-user role treatment)

Tests:
- `project.compliance.test.ts`: asserts `SmusUserRoleDeploymentRead` statement
- `project.synth.test.ts` Comprehensive SynthTest: asserts Allow and Deny statements include the `datazone_usr_role_*` ARN pattern

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
