### PR TITLE
fix(lakeformation-settings): use wildcard account in SSO application ARN

### DIFF
--- a/packages/apps/core/app/test/app.test.ts
+++ b/packages/apps/core/app/test/app.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 import { MdaaAppProps, MdaaCdkApp } from '../lib/app';
 import { MdaaL3ConstructProps } from '@aws-mdaa/l3-construct';
 import { MdaaAppConfigParserProps, MdaaSageMakerCustomBluePrintConfig } from '../lib/app_config';

--- a/packages/apps/governance/lakeformation-settings-app/test/__snapshots__/sample-config-comprehensive.baseline.json
+++ b/packages/apps/governance/lakeformation-settings-app/test/__snapshots__/sample-config-comprehensive.baseline.json
@@ -1199,7 +1199,7 @@
               "Effect": "Allow",
               "Resource": [
                 "arn:test-partition:sso:::instance/ssoins-test-instance-id",
-                "arn:test-partition:sso::test-account:application/ssoins-test-instance-id/*",
+                "arn:test-partition:sso::*:application/ssoins-test-instance-id/*",
                 "arn:aws:sso::aws:applicationProvider/*"
               ]
             },

--- a/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
+++ b/packages/constructs/L3/ai/sm-studio-domain-l3-construct/test/sm-studio-domain.test.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Mock aws-cdk-lib/aws-lambda to avoid Docker build during tests
+jest.mock('aws-cdk-lib/aws-lambda', () => {
+  const actual = jest.requireActual('aws-cdk-lib/aws-lambda');
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromDockerBuild: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+      fromCustomCommand: jest.fn().mockReturnValue({
+        bind: jest.fn().mockReturnValue({ s3Location: { bucketName: 'mock-bucket', objectKey: 'mock-key' } }),
+        bindToResource: jest.fn(),
+      }),
+    },
+  };
+});
+
+// Mock command-exists to simulate Docker availability
+jest.mock('command-exists', () => ({
+  sync: jest.fn().mockReturnValue(false), // Simulate Docker not available to use pip fallback
+}));
+
 /* eslint-disable jest/expect-expect */
 
 import { MdaaRoleHelper } from '@aws-mdaa/iam-role-helper';

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/lib/lakeformation-settings-l3-construct.ts
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/lib/lakeformation-settings-l3-construct.ts
@@ -95,7 +95,7 @@ export class LakeFormationSettingsL3Construct extends MdaaL3Construct {
       effect: Effect.ALLOW,
       resources: [
         idcInstanceArn,
-        `arn:${this.partition}:sso::${this.account}:application/${this.props.iamIdentityCenter.instanceId}/*`,
+        `arn:${this.partition}:sso::*:application/${this.props.iamIdentityCenter.instanceId}/*`,
         'arn:aws:sso::aws:applicationProvider/*',
       ],
       actions: [

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/conftest.py
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/conftest.py
@@ -1,0 +1,63 @@
+"""Shared pytest fixtures for LakeFormation Settings L3 Construct Python tests."""
+import pytest
+import os
+import sys
+
+# Set up AWS environment variables before any imports
+os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+os.environ['AWS_SESSION_TOKEN'] = 'testing'
+os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
+# Add all Lambda source directories to Python path
+lambda_dirs = [
+    'lakeformation_settings',
+    'lakeformation_idc_configs',
+]
+
+for lambda_dir in lambda_dirs:
+    src_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'python', lambda_dir)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mocked AWS Credentials for testing."""
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
+
+@pytest.fixture
+def lambda_context():
+    """Mock Lambda context for testing."""
+    class MockContext:
+        def __init__(self):
+            self.function_name = "lakeformation-settings-function"
+            self.function_version = "$LATEST"
+            self.remaining_time_in_millis = lambda: 30000
+            self.aws_request_id = "test-request-id"
+            self.log_stream_name = "test-log-stream"
+
+    return MockContext()
+
+
+@pytest.fixture
+def env_vars():
+    """Set up environment variables for testing."""
+    env_vars = {
+        'USER_AGENT_STRING': 'test-solution/1.0.0',
+        'LOG_LEVEL': 'INFO'
+    }
+
+    for key, value in env_vars.items():
+        os.environ[key] = value
+
+    yield env_vars
+
+    for key in env_vars.keys():
+        os.environ.pop(key, None)

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/pyproject.toml
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "lakeformation-settings-tests"
+version = "0.1.0"
+description = "LakeFormation Settings L3 Construct Lambda Function Tests"
+requires-python = ">=3.9"
+dependencies = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+    "pytest-mock>=3.11.1",
+    "boto3>=1.28.0",
+    "botocore>=1.31.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--verbose",
+    "--tb=short",
+]
+
+[tool.coverage.run]
+source = ["../src/python"]
+omit = [
+    "*/tests/*",
+    "*/test_*",
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+]

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/test_lakeformation_idc_configs.py
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/test_lakeformation_idc_configs.py
@@ -1,0 +1,83 @@
+"""Tests for LakeFormation IDC Configs Lambda function."""
+import pytest
+from unittest.mock import patch, MagicMock
+import lakeformation_idc_configs
+
+
+@patch('lakeformation_idc_configs.lf_client')
+def test_lambda_handler_create(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Create',
+        'ResourceProperties': {
+            'instanceArn': 'arn:aws:sso:::instance/test-instance',
+            'shareRecipients': [{'DataLakePrincipalIdentifier': '123456789012'}],
+        }
+    }
+    mock_client.create_lake_formation_identity_center_configuration.return_value = {
+        'ApplicationArn': 'arn:aws:sso::123456789012:application/test-instance/apl-test'
+    }
+
+    result = lakeformation_idc_configs.lambda_handler(event, lambda_context)
+
+    mock_client.create_lake_formation_identity_center_configuration.assert_called_once_with(
+        InstanceArn='arn:aws:sso:::instance/test-instance',
+        ShareRecipients=[{'DataLakePrincipalIdentifier': '123456789012'}]
+    )
+    assert result['Status'] == 'SUCCESS'
+    assert result['PhysicalResourceId'] == 'arn:aws:sso::123456789012:application/test-instance/apl-test'
+
+
+@patch('lakeformation_idc_configs.lf_client')
+def test_lambda_handler_create_no_recipients(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Create',
+        'ResourceProperties': {
+            'instanceArn': 'arn:aws:sso:::instance/test-instance',
+        }
+    }
+    mock_client.create_lake_formation_identity_center_configuration.return_value = {
+        'ApplicationArn': 'arn:aws:sso::123456789012:application/test-instance/apl-test'
+    }
+
+    result = lakeformation_idc_configs.lambda_handler(event, lambda_context)
+
+    mock_client.create_lake_formation_identity_center_configuration.assert_called_once_with(
+        InstanceArn='arn:aws:sso:::instance/test-instance',
+        ShareRecipients=[]
+    )
+    assert result['Status'] == 'SUCCESS'
+
+
+@patch('lakeformation_idc_configs.lf_client')
+def test_lambda_handler_update(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Update',
+        'ResourceProperties': {
+            'instanceArn': 'arn:aws:sso:::instance/test-instance',
+            'shareRecipients': [{'DataLakePrincipalIdentifier': '111111111111'}],
+        }
+    }
+    mock_client.update_lake_formation_identity_center_configuration.return_value = {}
+
+    result = lakeformation_idc_configs.lambda_handler(event, lambda_context)
+
+    mock_client.update_lake_formation_identity_center_configuration.assert_called_once_with(
+        ShareRecipients=[{'DataLakePrincipalIdentifier': '111111111111'}]
+    )
+    assert result['Status'] == 'SUCCESS'
+
+
+@patch('lakeformation_idc_configs.lf_client')
+def test_lambda_handler_delete(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Delete',
+        'ResourceProperties': {
+            'instanceArn': 'arn:aws:sso:::instance/test-instance',
+        }
+    }
+    mock_client.delete_lake_formation_identity_center_configuration.return_value = {}
+
+    result = lakeformation_idc_configs.lambda_handler(event, lambda_context)
+
+    mock_client.delete_lake_formation_identity_center_configuration.assert_called_once_with()
+    assert result['Status'] == 'SUCCESS'

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/test_lakeformation_settings.py
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/python-tests/test_lakeformation_settings.py
@@ -1,0 +1,63 @@
+"""Tests for LakeFormation Settings Lambda function."""
+import pytest
+from unittest.mock import patch, MagicMock
+import lakeformation_settings
+
+
+@patch('lakeformation_settings.lf_client')
+def test_lambda_handler_create(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Create',
+        'ResourceProperties': {
+            'account': 'test-account',
+            'dataLakeSettings': {
+                'DataLakeAdmins': [{'DataLakePrincipalIdentifier': 'arn:aws:iam::123456789012:role/TestRole'}],
+            }
+        }
+    }
+    mock_client.put_data_lake_settings.return_value = {}
+
+    result = lakeformation_settings.lambda_handler(event, lambda_context)
+
+    mock_client.put_data_lake_settings.assert_called_once_with(
+        DataLakeSettings=event['ResourceProperties']['dataLakeSettings']
+    )
+    assert result['Status'] == 'SUCCESS'
+    assert result['PhysicalResourceId'] == 'test-account'
+
+
+@patch('lakeformation_settings.lf_client')
+def test_lambda_handler_update(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Update',
+        'ResourceProperties': {
+            'account': 'test-account',
+            'dataLakeSettings': {
+                'DataLakeAdmins': [],
+            }
+        }
+    }
+    mock_client.put_data_lake_settings.return_value = {}
+
+    result = lakeformation_settings.lambda_handler(event, lambda_context)
+
+    mock_client.put_data_lake_settings.assert_called_once_with(
+        DataLakeSettings=event['ResourceProperties']['dataLakeSettings']
+    )
+    assert result['Status'] == 'SUCCESS'
+
+
+@patch('lakeformation_settings.lf_client')
+def test_lambda_handler_delete(mock_client, aws_credentials, lambda_context):
+    event = {
+        'RequestType': 'Delete',
+        'ResourceProperties': {
+            'account': 'test-account',
+            'dataLakeSettings': {}
+        }
+    }
+
+    result = lakeformation_settings.lambda_handler(event, lambda_context)
+
+    mock_client.put_data_lake_settings.assert_not_called()
+    assert result['Status'] == 'SUCCESS'

--- a/packages/constructs/L3/governance/lakeformation-settings-l3-construct/test/lakeformation-settings.compliance.test.ts
+++ b/packages/constructs/L3/governance/lakeformation-settings-l3-construct/test/lakeformation-settings.compliance.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { MdaaTestApp } from '@aws-mdaa/testing';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { MdaaRoleHelper, MdaaRoleRef } from '@aws-mdaa/iam-role-helper';
 
 import { LakeFormationSettingsL3ConstructProps, LakeFormationSettingsL3Construct } from '../lib';
@@ -35,8 +35,6 @@ describe('MDAA Compliance Stack Tests', () => {
   new LakeFormationSettingsL3Construct(stack, 'teststack', constructProps);
   testApp.checkCdkNagCompliance(testApp.testStack);
   const template = Template.fromStack(testApp.testStack);
-
-  console.log(JSON.stringify(template, undefined, 2));
 
   test('LakeFormationSettings', () => {
     template.hasResourceProperties('Custom::lakeformation-settings', {
@@ -84,6 +82,22 @@ describe('MDAA Compliance Stack Tests', () => {
       ],
     });
   });
+
+  test('LF-IdC Lambda execution role uses wildcard account in SSO application ARN', () => {
+    // SSO app ARNs carry the management-account ID, not the deploying account — wildcard is required
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Action: Match.arrayWith(['sso:PutApplicationAssignmentConfiguration']),
+            Resource: Match.arrayWith(['arn:test-partition:sso::*:application/test-sso-instance/*']),
+          }),
+        ]),
+      },
+    });
+  });
+
   test('DZ Management Role', () => {
     template.hasResourceProperties('AWS::IAM::Role', {
       AssumeRolePolicyDocument: {


### PR DESCRIPTION
*Issue #, if available:* #45

*Description of changes:*


SSO application ARNs carry the IdC management account ID (the Control Tower management or delegated SSO admin account), not the data-platform account where the CDK stack is deployed. Using `this.account` in the resource ARN causes an AccessDeniedException when the two accounts differ.

Replace `${this.account}` with `*` in the `sso:PutApplicationAssignmentConfiguration` resource ARN so the policy covers same-account and cross-account IdC setups. The scope remains constrained by the specific SSO instance ID.

Tests:
- `lakeformation-settings.compliance.test.ts`: assert wildcard account in SSO application ARN on the Lambda execution role policy
- Python tests added (`conftest.py`, `pyproject.toml`, `test_lakeformation_idc_configs.py`, `test_lakeformation_settings.py`) for the Lambda handler
- `app.test.ts` and `sm-studio-domain.test.ts`: add Lambda/Docker mocks to fix unrelated test isolation failures surfaced during review

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
